### PR TITLE
Add mode manager for easy toggle between competition and demo

### DIFF
--- a/.Glass/glass.json
+++ b/.Glass/glass.json
@@ -1,9 +1,34 @@
 {
+  "NetworkTables": {
+    "retained": {
+      "AdvantageKit": {
+        "DashboardInputs": {
+          "open": true
+        },
+        "open": true
+      },
+      "SmartDashboard": {
+        "open": true
+      }
+    },
+    "types": {
+      "/FMSInfo": "FMSInfo",
+      "/SmartDashboard/Autonomous Routine": "String Chooser",
+      "/SmartDashboard/Mech2d": "Mechanism2d",
+      "/SmartDashboard/Robot Mode": "String Chooser"
+    }
+  },
   "NetworkTables Info": {
+    "Clients": {
+      "open": true
+    },
+    "Server": {
+      "open": true
+    },
     "visible": true
   },
   "NetworkTables Settings": {
     "mode": "Client (NT4)",
-    "serverTeam": "127.0.0.1"
+    "serverTeam": "10.27.13.1"
   }
 }

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -12,6 +12,7 @@ import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
 import edu.wpi.first.math.util.Units;
+import frc.robot.Robot.RobotMode;
 import frc.robot.subsystems.swerveIO.module.ModuleInfo;
 import frc.robot.subsystems.swerveIO.module.SwerveModuleName;
 import frc.robot.subsystems.visionIO.VisionInfo;
@@ -208,7 +209,7 @@ public final class Constants {
     public static final double MAX_HEIGHT_METERS = Units.inchesToMeters(17);
     public static final double STARTING_HEIGHT_METERS = Units.inchesToMeters(2);
     public static final boolean SIMULATE_GRAVITY = true;
-    public static final int ELEVATOR_CURRENT_LIMIT = 30;
+    public static final int ELEVATOR_CURRENT_LIMIT = Robot.modeManager.getMode() == RobotMode.DEMO ? 15 : 30;
     public static final double FLOOR_TO_ELEVATOR_BASE_METRES = Units.inchesToMeters(31.25);
   }
 

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -998,7 +998,6 @@ public class Robot extends LoggedRobot {
     }
     swerveDrive.seed();
     swerveDrive.setMotionMode(MotionMode.LOCKDOWN);
-    
   }
 
   @Override

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -106,7 +106,7 @@ public class Robot extends LoggedRobot {
   private final LoggedDashboardChooser<RHRFullRoutine> autoChooser =
       new LoggedDashboardChooser<>("Autonomous Routine");
   private final LoggedDashboardChooser<RobotMode> modeChooser =
-    new LoggedDashboardChooser<>("Robot Mode");
+      new LoggedDashboardChooser<>("Robot Mode");
 
   private ChangeDetector<Optional<Alliance>> allianceChangeDetector;
   private ChangeDetector<RHRFullRoutine> autoChangeDetector;
@@ -1080,9 +1080,8 @@ public class Robot extends LoggedRobot {
   }
 
   public void buildModeChooser() {
-    modeChooser.addDefaultOption(modeManager.getMode().toString(), Robot.modeManager.getMode());
+    modeChooser.addDefaultOption("Competition", RobotMode.COMPETITION);
     modeChooser.addOption("Demo", RobotMode.DEMO);
-    modeChooser.addOption("Competition", RobotMode.COMPETITION);
   }
 
   public void updatePreMatchDashboardValues() {

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -998,6 +998,7 @@ public class Robot extends LoggedRobot {
     }
     swerveDrive.seed();
     swerveDrive.setMotionMode(MotionMode.LOCKDOWN);
+    
   }
 
   @Override
@@ -1130,6 +1131,7 @@ public class Robot extends LoggedRobot {
   public void driverStationConnected() {
 
     buildAutoChooser();
+    buildModeChooser();
     if (autoChooser.get() != null) {
       gyroInitial = autoChooser.get().traj1.getInitialPose().getRotation();
     }

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -67,6 +67,7 @@ import frc.robot.subsystems.visionIO.VisionIOLimelightLib;
 import frc.robot.subsystems.visionIO.VisionIOSim;
 import frc.robot.util.ChangeDetector;
 import frc.robot.util.MechanismManager;
+import frc.robot.util.ModeManager;
 import frc.robot.util.RedHawkUtil;
 import frc.robot.util.RumbleManager;
 import frc.robot.util.SwerveHeadingController;
@@ -104,10 +105,19 @@ public class Robot extends LoggedRobot {
   private Command autoCommand;
   private final LoggedDashboardChooser<RHRFullRoutine> autoChooser =
       new LoggedDashboardChooser<>("Autonomous Routine");
+  private final LoggedDashboardChooser<RobotMode> modeChooser =
+    new LoggedDashboardChooser<>("Robot Mode");
 
   private ChangeDetector<Optional<Alliance>> allianceChangeDetector;
   private ChangeDetector<RHRFullRoutine> autoChangeDetector;
+  private ChangeDetector<RobotMode> modeChangeDetector;
   private Rotation2d gyroInitial = Rotation2d.fromRadians(0);
+  public static final ModeManager modeManager = new ModeManager(RobotMode.DEMO);
+
+  public enum RobotMode {
+    DEMO,
+    COMPETITION
+  }
 
   @Override
   public void robotInit() {
@@ -198,6 +208,12 @@ public class Robot extends LoggedRobot {
             (auto) -> {
               gyroInitial = auto.traj1.getInitialPose().getRotation();
               seedGyroBasedOnAlliance();
+            });
+
+    modeChangeDetector =
+        new ChangeDetector<>(
+            (mode) -> {
+              modeManager.setMode(mode);
             });
   }
 
@@ -989,6 +1005,7 @@ public class Robot extends LoggedRobot {
     swerveDrive.seed();
     allianceChangeDetector.feed(DriverStation.getAlliance());
     autoChangeDetector.feed(autoChooser.get());
+    modeChangeDetector.feed(modeChooser.get());
   }
 
   @Override
@@ -1060,6 +1077,12 @@ public class Robot extends LoggedRobot {
     autoChooser.addOption("NopeSource", new NopeSource());
     autoChooser.addOption("NopeSourceIntake", new NopeSourceIntake());
     autoChooser.addOption("NopeAmp", new NopeAmp());
+  }
+
+  public void buildModeChooser() {
+    modeChooser.addDefaultOption(modeManager.getMode().toString(), Robot.modeManager.getMode());
+    modeChooser.addOption("Demo", RobotMode.DEMO);
+    modeChooser.addOption("Competition", RobotMode.COMPETITION);
   }
 
   public void updatePreMatchDashboardValues() {

--- a/src/main/java/frc/robot/util/ModeManager.java
+++ b/src/main/java/frc/robot/util/ModeManager.java
@@ -1,0 +1,21 @@
+package frc.robot.util;
+
+import frc.robot.Robot.RobotMode;
+
+public class ModeManager 
+{
+    private RobotMode mode;
+    
+    public ModeManager(RobotMode initialMode) {
+        this.mode = initialMode;
+    }
+    
+    public RobotMode getMode() {
+        return this.mode;
+    }
+
+    public void setMode(RobotMode newMode) {
+        this.mode = newMode;
+    }
+}
+

--- a/src/main/java/frc/robot/util/ModeManager.java
+++ b/src/main/java/frc/robot/util/ModeManager.java
@@ -2,20 +2,18 @@ package frc.robot.util;
 
 import frc.robot.Robot.RobotMode;
 
-public class ModeManager 
-{
-    private RobotMode mode;
-    
-    public ModeManager(RobotMode initialMode) {
-        this.mode = initialMode;
-    }
-    
-    public RobotMode getMode() {
-        return this.mode;
-    }
+public class ModeManager {
+  private RobotMode mode;
 
-    public void setMode(RobotMode newMode) {
-        this.mode = newMode;
-    }
+  public ModeManager(RobotMode initialMode) {
+    this.mode = initialMode;
+  }
+
+  public RobotMode getMode() {
+    return this.mode;
+  }
+
+  public void setMode(RobotMode newMode) {
+    this.mode = newMode;
+  }
 }
-

--- a/src/main/java/frc/robot/util/MotionHandler.java
+++ b/src/main/java/frc/robot/util/MotionHandler.java
@@ -53,7 +53,7 @@ public class MotionHandler {
    * @return The desired array of desaturated swerveModuleStates.
    */
   public static ChassisSpeeds driveFullControl() {
-    double speedFactor = Robot.modeManager.getMode() == RobotMode.DEMO ? 0.5 : 1; 
+    double speedFactor = Robot.modeManager.getMode() == RobotMode.DEMO ? 0.5 : 1;
 
     double xSpeed =
         MathUtil.applyDeadband(-Robot.driver.getLeftY(), DriveConstants.K_JOYSTICK_TURN_DEADZONE)

--- a/src/main/java/frc/robot/util/MotionHandler.java
+++ b/src/main/java/frc/robot/util/MotionHandler.java
@@ -8,6 +8,7 @@ import edu.wpi.first.math.kinematics.SwerveModuleState;
 import edu.wpi.first.math.util.Units;
 import frc.robot.Constants.DriveConstants;
 import frc.robot.Robot;
+import frc.robot.Robot.RobotMode;
 import frc.robot.VehicleState;
 import frc.robot.commands.otf.RotateScore;
 import frc.robot.rhr.auto.RHRTrajectoryController;
@@ -52,7 +53,7 @@ public class MotionHandler {
    * @return The desired array of desaturated swerveModuleStates.
    */
   public static ChassisSpeeds driveFullControl() {
-    double speedFactor = 1; // Robot.driver.rightBumper().getAsBoolean() ? 0.33 : 1.0;
+    double speedFactor = Robot.modeManager.getMode() == RobotMode.DEMO ? 0.5 : 1; 
 
     double xSpeed =
         MathUtil.applyDeadband(-Robot.driver.getLeftY(), DriveConstants.K_JOYSTICK_TURN_DEADZONE)

--- a/src/main/java/frc/robot/util/MotionHandler.java
+++ b/src/main/java/frc/robot/util/MotionHandler.java
@@ -53,7 +53,7 @@ public class MotionHandler {
    * @return The desired array of desaturated swerveModuleStates.
    */
   public static ChassisSpeeds driveFullControl() {
-    double speedFactor = Robot.modeManager.getMode() == RobotMode.DEMO ? 0.01 : 1;
+    double speedFactor = Robot.modeManager.getMode() == RobotMode.DEMO ? 0.1 : 1;
 
     double xSpeed =
         MathUtil.applyDeadband(-Robot.driver.getLeftY(), DriveConstants.K_JOYSTICK_TURN_DEADZONE)

--- a/src/main/java/frc/robot/util/MotionHandler.java
+++ b/src/main/java/frc/robot/util/MotionHandler.java
@@ -53,7 +53,7 @@ public class MotionHandler {
    * @return The desired array of desaturated swerveModuleStates.
    */
   public static ChassisSpeeds driveFullControl() {
-    double speedFactor = Robot.modeManager.getMode() == RobotMode.DEMO ? 0.5 : 1;
+    double speedFactor = Robot.modeManager.getMode() == RobotMode.DEMO ? 0.01 : 1;
 
     double xSpeed =
         MathUtil.applyDeadband(-Robot.driver.getLeftY(), DriveConstants.K_JOYSTICK_TURN_DEADZONE)


### PR DESCRIPTION
Adds a Robot mode manager to easily switch between demo and competition mode.
That mode should be accessible throughout the Robot code to define speeds, acceleration and other factors to make it safer to operate during demos.
This also makes the Robot mode setter accessible from the Elastic dashboard.
We've tested this code on the robot last Tuesday. 